### PR TITLE
Vexcl support

### DIFF
--- a/include/tapes/chunk.hpp
+++ b/include/tapes/chunk.hpp
@@ -407,8 +407,8 @@ namespace codi {
      */
     CODI_INLINE void dataPointer(const size_t& index, Data1* &pointer1, Data2* &pointer2) {
       codiAssert(index <= ChunkInterface::size);
-      pointer1 = &data1[index];
-      pointer2 = &data2[index];
+      pointer1 = codi::addressof(data1[index]);
+      pointer2 = codi::addressof(data2[index]);
     }
   };
 

--- a/include/tapes/forwardEvaluation.hpp
+++ b/include/tapes/forwardEvaluation.hpp
@@ -163,7 +163,7 @@ namespace codi {
     template<typename Data>
     CODI_INLINE void pushJacobi(Data& lhsTangent, const Real& jacobi, const Real& value, const GradientData& curTangent) {
       CODI_UNUSED(value);
-      ENABLE_CHECK(OptIgnoreInvalidJacobies, isfinite(jacobi)) {
+      ENABLE_CHECK(OptIgnoreInvalidJacobies, codi::isfinite(jacobi)) {
         lhsTangent += jacobi * curTangent;
       }
     }

--- a/include/tapes/modules/jacobiModule.tpp
+++ b/include/tapes/modules/jacobiModule.tpp
@@ -209,7 +209,7 @@
       CODI_UNUSED(data);
       CODI_UNUSED(value);
       ENABLE_CHECK(OptCheckZeroIndex, 0 != index) {
-        ENABLE_CHECK(OptIgnoreInvalidJacobies, isfinite(jacobi)) {
+        ENABLE_CHECK(OptIgnoreInvalidJacobies, codi::isfinite(jacobi)) {
           ENABLE_CHECK(OptJacobiIsZero, !isTotalZero(jacobi)) {
             this->jacobiVector.setDataAndMove(jacobi, index);
           }

--- a/include/typeFunctions.hpp
+++ b/include/typeFunctions.hpp
@@ -92,4 +92,22 @@ namespace codi {
   CODI_INLINE
   typename addressof_impl<T>::pointer_type addressof(T& t) {
     return addressof_impl<T>::get(t); }
+
+
+#ifndef DOXYGEN_DISABLE
+  // check is variable is finite
+  template <typename T, typename Enable = void>
+  struct isfinite_impl {
+      static CODI_INLINE bool get(const T &t) {
+          return isfinite(t);
+      }
+  };
+#endif
+
+  /**
+   * @brief Check if variable is finite
+   */
+  template <typename T>
+  CODI_INLINE bool isfinite(const T& t) {
+    return isfinite_impl<T>::get(t); }
 }

--- a/include/typeFunctions.hpp
+++ b/include/typeFunctions.hpp
@@ -36,25 +36,25 @@
 namespace codi {
 
 #ifndef DOXYGEN_DISABLE
-  // default definition
-  template <typename T, const bool isArithmetic>
-  struct IsTotalZeroImpl {};
+  // default definition. call t.isTotalZero()
+  template <typename T, typename Enable = void>
+  struct IsTotalZeroImpl {
+      static CODI_INLINE bool isTotalZero(const T &t) {
+        return t.isTotalZero();
+      }
+  };
 
   //call t == 0 for all arithmetic types e.g. double, int @internal */
   template <typename T>
-  struct IsTotalZeroImpl<T, true> {
+  struct IsTotalZeroImpl<T,
+      typename std::enable_if<std::is_arithmetic<T>::value>::type
+      >
+  {
       static CODI_INLINE bool isTotalZero(const T &t) {
         return t == T();
       }
   };
 
-  //call t.isTotalZero for all other types */
-  template <typename T>
-  struct IsTotalZeroImpl<T, false> {
-      static CODI_INLINE bool isTotalZero(const T &t) {
-        return t.isTotalZero();
-      }
-  };
 #endif
 
   /**
@@ -71,7 +71,7 @@ namespace codi {
    */
   template <typename T>
   CODI_INLINE bool isTotalZero(const T& t) {
-    return IsTotalZeroImpl<T, std::is_arithmetic<T>::value>::isTotalZero(t);}
+    return IsTotalZeroImpl<T>::isTotalZero(t);}
 
 #ifndef DOXYGEN_DISABLE
   // Take address of a T instance

--- a/include/typeFunctions.hpp
+++ b/include/typeFunctions.hpp
@@ -72,4 +72,24 @@ namespace codi {
   template <typename T>
   CODI_INLINE bool isTotalZero(const T& t) {
     return IsTotalZeroImpl<T, std::is_arithmetic<T>::value>::isTotalZero(t);}
+
+#ifndef DOXYGEN_DISABLE
+  // Take address of a T instance
+  template <typename T, typename Enable = void>
+  struct addressof_impl {
+      typedef typename std::add_pointer<T>::type pointer_type;
+
+      static CODI_INLINE pointer_type get(T &t) {
+          return &t;
+      }
+  };
+#endif
+
+  /**
+   * @brief Return address of a variable
+   */
+  template <typename T>
+  CODI_INLINE
+  typename addressof_impl<T>::pointer_type addressof(T& t) {
+    return addressof_impl<T>::get(t); }
 }


### PR DESCRIPTION
This is an attempt to make structs in `typeFunctions.hpp` extensible enough to accomodate VexCL symbolic types. See the corresponding implementations in codipack_vexcl:  [codi_vexcl_adaptor.hpp](https://bitbucket.org/d_demidov/codipack_vexcl/src/7af310ae6a73e97c6f874ffa19fd410f6b54229f/codi_vexcl_adaptor.hpp?fileviewer=file-view-default).

One thing I am not sure is the new `codi::isfinite` function and the corresponding `impl` struct. It looks like `isfinite` was extended in [`expressions.hpp`](https://github.com/SciCompKL/CoDiPack/blob/63f81963688520036063c5c6e73f076383055938/include/expressions.hpp#L1158); those probably need to be adapted to use the new functionality.