### PR TITLE
Add operator overload for ActiveReal

### DIFF
--- a/include/activeReal.hpp
+++ b/include/activeReal.hpp
@@ -357,6 +357,14 @@ namespace codi {
     }
 
     /**
+     * @brief Get the primal value of this instance via implicit cast.
+     * @return The primal value.
+     */
+    CODI_INLINE operator Real() const {
+      return primalValue;
+    }
+
+    /**
      * @brief Set the primal value of this instance.
      * @param value The new primal value.
      */


### PR DESCRIPTION
This removes the need to call value() in many situations.