### PR TITLE
Move implicit cast operator from ActiveReal to Expression

### DIFF
--- a/include/codi/activeReal.hpp
+++ b/include/codi/activeReal.hpp
@@ -356,18 +356,6 @@ namespace codi {
       return primalValue;
     }
 
-#if CODI_EnableImplicitConversion
-    /**
-     * @brief Get the primal value of this instance via implicit cast.
-     * @return The primal value.
-     */
-    CODI_INLINE operator Real() const {
-      Warning::implicitCast<CODI_DisableImplicitConversionWarning>();
-
-      return primalValue;
-    }
-#endif
-
     /**
      * @brief Set the primal value of this instance.
      * @param value The new primal value.

--- a/include/codi/expressions.hpp
+++ b/include/codi/expressions.hpp
@@ -154,6 +154,18 @@ namespace codi {
       cast().valueAction(data, func);
     }
 
+#if CODI_EnableImplicitConversion
+    /**
+     * @brief Get the primal value of this instance via implicit cast.
+     * @return The primal value.
+     */
+    CODI_INLINE operator const Real() const {
+      Warning::implicitCast<CODI_DisableImplicitConversionWarning>();
+
+      return getValue();
+    }
+#endif
+
   private:
     /**
      * Intentionally inaccessible to prevent an expression appearing


### PR DESCRIPTION
This fixes the following test case:

```cpp
    AD_Real v0 = 0.;
    AD_Real v1 = 1.;
    AD_Real r0 = (int)(v0+v1); // invalid because (v0+v1) is a Mult11<...> which derives from Expression
```

See #6 for background on the issue; this edit is a generalization of the solution from that pull request.

Thanks!