### PR TITLE
Evaluator class drafted after Julia's DiffResults.jl

### DIFF
--- a/documentation/evaluator-test11.cpp
+++ b/documentation/evaluator-test11.cpp
@@ -1,0 +1,62 @@
+//
+// Test codi::Evaluator with classical C++ functor classes
+//
+
+
+#include <iostream>
+#include <cstdio>
+#include <codi.hpp>
+
+
+
+struct myfunctor
+{
+  template<class V>
+  void operator()(const V &x, V &y)
+  {
+    y[0]=sin(x[0]);
+  }
+};
+
+
+struct myfunctor2
+{
+  template<class V>
+  void operator()(const V &x, V &y)
+  {
+    y[0]=x[0]*11+ x[1]*12;
+    y[1]=x[0]*21+x[1]*22;
+  }
+};
+
+
+int main() 
+{
+  auto myfunc=myfunctor();
+  
+  auto evaluator= codi::Evaluator<myfunctor>(1,1,myfunc);
+
+  std::vector<double> xx(1);
+  std::vector<double> yy(1);
+
+  for (double x=0.0; x<10.0; x+=1.0)
+  {
+    xx[0]=x;
+    evaluator.call(xx);
+    printf("f(x)=%g f'(x)=%g cos(x)=%g\n", evaluator.result(0),evaluator.jacobian(0,0),cos(x));
+  }
+
+  auto myfunc2=myfunctor2();
+  auto evaluator2=codi::Evaluator<myfunctor2>(2,2,myfunc2);
+  std::vector<double> xx2(2);
+  std::vector<double> yy2(2);
+
+  
+  xx2[0]=1;
+  xx2[1]=1;
+  evaluator2.call(xx2);
+  printf("f:  %g %g\n",evaluator2.result(0), evaluator2.result(1));
+  printf("f': %g %g\n",evaluator2.jacobian(0,0),evaluator2.jacobian(0,1));
+  printf("    %g %g\n",evaluator2.jacobian(1,0),evaluator2.jacobian(1,1));
+  return 0;
+}

--- a/documentation/evaluator-test14.cpp
+++ b/documentation/evaluator-test14.cpp
@@ -1,0 +1,50 @@
+//
+// Test codi::Evaluator with c++14 generic lambdas
+//
+
+#include <iostream>
+#include <cstdio>
+#include <codi.hpp>
+
+
+
+int main() 
+{
+
+  auto myfunc=[](const auto  &x, auto &y)
+    {
+      y[0]=sin(x[0]);
+    };
+  
+  auto evaluator= codi::Evaluator<decltype(myfunc)>(1,1,myfunc);
+
+  std::vector<double> xx(1);
+  std::vector<double> yy(1);
+
+  for (double x=0.0; x<10.0; x+=1.0)
+  {
+    xx[0]=x;
+    evaluator.call(xx);
+    printf("f(x)=%g f'(x)=%g cos(x)=%g\n", evaluator.result(0),evaluator.jacobian(0,0),cos(x));
+  }
+
+
+  auto myfunc2=[](const auto &x, auto &y)
+  {
+    y[0]=x[0]*11+x[1]*12;
+    y[1]=x[0]*21+x[1]*22;
+  };
+
+  auto evaluator2=codi::Evaluator<decltype(myfunc2)>(2,2,myfunc2);
+  std::vector<double> xx2(2);
+  std::vector<double> yy2(2);
+
+  
+  xx2[0]=1;
+  xx2[1]=1;
+  evaluator2.call(xx2);
+  printf("f:  %g %g\n",evaluator2.result(0), evaluator2.result(1));
+  printf("f': %g %g\n",evaluator2.jacobian(0,0),evaluator2.jacobian(0,1));
+  printf("    %g %g\n",evaluator2.jacobian(1,0),evaluator2.jacobian(1,1));
+  return 0;
+}

--- a/documentation/evaluator-test17.cpp
+++ b/documentation/evaluator-test17.cpp
@@ -1,0 +1,50 @@
+//
+// Test codi::Evaluator with c++14 generic lambdas and C++ 17 template argument deduction
+//
+// This now very much looks like what can be done with Julia
+//
+#include <iostream>
+#include <cstdio>
+#include <codi.hpp>
+
+
+
+int main() 
+{
+
+  auto myfunc=[](const auto  &x, auto &y)
+    {
+      y[0]=sin(x[0]);
+    };
+  
+  auto evaluator= codi::Evaluator(1,1,myfunc);
+
+  std::vector<double> xx(1);
+  std::vector<double> yy(1);
+
+  for (double x=0.0; x<10.0; x+=1.0)
+  {
+    xx[0]=x;
+    evaluator.call(xx);
+    printf("f(x)=%g f'(x)=%g cos(x)=%g\n", evaluator.result(0),evaluator.jacobian(0,0),cos(x));
+  }
+
+
+  auto myfunc2=[](const auto &x, auto &y)
+  {
+    y[0]=x[0]*11+x[1]*12;
+    y[1]=x[0]*21+x[1]*22;
+  };
+  
+  auto evaluator2=codi::Evaluator(2,2,myfunc2);
+  std::vector<double> xx2(2);
+  std::vector<double> yy2(2);
+  
+  xx2[0]=1;
+  xx2[1]=1;
+  evaluator2.call(xx2);
+  printf("f:  %g %g\n",evaluator2.result(0), evaluator2.result(1));
+  printf("f': %g %g\n",evaluator2.jacobian(0,0),evaluator2.jacobian(0,1));
+  printf("    %g %g\n",evaluator2.jacobian(1,0),evaluator2.jacobian(1,1));
+  return 0;
+}

--- a/include/codi.hpp
+++ b/include/codi.hpp
@@ -358,3 +358,7 @@ namespace codi {
    */
   typedef RealReversePrimalIndexUncheckedGen<double, double> RealReversePrimalIndexUnchecked;
 }
+
+// codi::Evaluator needs RealForwardVec
+#include "codi/evaluator.hpp"
+

--- a/include/codi/evaluator-macros.h
+++ b/include/codi/evaluator-macros.h
@@ -1,0 +1,47 @@
+// This file is included multiple times
+// each time CODE is defined differently
+CODE(1)
+CODE(2)
+CODE(3)
+CODE(4)
+CODE(5)
+CODE(6)
+CODE(7)
+CODE(8)
+CODE(9)
+CODE(10)
+CODE(11)
+CODE(12)
+CODE(13)
+CODE(14)
+CODE(15)
+CODE(16)
+CODE(17)
+CODE(18)
+CODE(19)
+CODE(20)
+CODE(21)
+CODE(22)
+CODE(23)
+CODE(24)
+CODE(25)
+CODE(26)
+CODE(27)
+CODE(28)
+CODE(29)
+CODE(30)
+CODE(31)
+CODE(32)
+CODE(33)
+CODE(34)
+CODE(35)
+CODE(36)
+CODE(37)
+CODE(38)
+CODE(39)
+
+// When extending this for more dimensions, do not forget
+// to bump CODI_MAXDIM
+#ifndef CODI_MAXDIM
+#define CODI_MAXDIM 39
+#endif

--- a/include/codi/evaluator.hpp
+++ b/include/codi/evaluator.hpp
@@ -1,0 +1,214 @@
+/**
+ * Evaluator class (draft by J. Fuhrmann <juergen.fuhrmann@wias-berlin.de>)
+ * This has been inspired by JuliaDiff/DiffResults.jl. The main purpose is to provide a convenient way
+ * to evaluate function and jacobian at once, as it is often used in Newton solvers.
+ **/
+
+
+#include <exception>
+#include <vector>
+
+namespace codi
+{
+
+  /**
+   * @brief Evaluator of value and jacobian of vector function with origin dimension as template parameter
+   *
+   *
+   * It takes as template argument a function f(x,y) mapping an origin vector x of dimension nx to
+   * an image vector y of dimension ny and allows to evaluate function and derivative.
+   *
+   * The vector data type is variable, by default, std::vector is used.
+   */
+  template <
+    class FUNC, // Function  R^nx -> R^ny
+    int NX,     // Fixed  origin dimension
+    template<class T, class ALLOC> class VECTOR=std::vector
+    >
+  class FixedDimensionEvaluator
+  {
+    typedef RealForwardVec<NX> codivec;  // CODI vector type
+
+  private:
+    FUNC func;      // Function to be evaluated
+    const int nx;   // Origin dimension
+    const int ny;   // Image dimension
+    VECTOR<codivec,std::allocator<codivec>> x; // Vector of unknown values
+    VECTOR<codivec,std::allocator<codivec>> y; // Vector of result values
+    
+  public:
+    FixedDimensionEvaluator(int nx, int ny, FUNC& func):
+      func(func),
+      nx(nx),
+      ny(ny),
+      x(nx),
+      y(ny)
+    {
+      if (nx!=NX)
+        throw std::domain_error("codi::FixedDimensionEvaluator: template parameter NX must coincide with origin dimension nx.");
+    };
+
+    /**
+     * @brief Call function for vector x
+     *
+     * Note: we might check for matching dimensions
+     */
+    template <class V>
+    void call(const V &x)
+    {
+      // Initialize x and gradient
+      for (int i=0;i<nx;i++)
+      {
+        this->x[i]=x[i];
+        this->x[i].gradient()[i]=1.0;
+      }
+      // Call function 
+      func(this->x,this->y);
+    }
+
+    
+    /**
+     * @brief Retrieve function value f_i(x)
+     *
+     * Note: we might check for matching dimensions
+     */
+    double result(int i)
+    {
+      return y[i].getValue();
+    }
+
+    /**
+     * @brief Retrieve jacobian value at d f_i(x)/d x_j
+     *
+     * Note: we might check for matching dimensions
+     */
+    double jacobian(int i, int j)
+    {
+      return y[i].getGradient()[j];
+    }
+  };
+  
+  
+  
+  /**
+   * @brief Evaluator of value and jacobian of vector function with arbitrary origin dimension
+   *
+   * It takes as template argument a function f(x,y) mapping an origin vector x of dimension nx to
+   * an image vector y of dimension ny and allows to evaluate function and derivative.
+   *
+   * The vector data type is variable, by default, std::vector is used.
+   */
+  template <
+    class FUNC,  // Function  R^nx -> R^ny
+    template <class T, class ALLOC> class VECTOR=std::vector // vector type
+    >
+  class Evaluator
+  {
+    const int nx;
+
+    // Work around  fixed origin dimension: create a union of FixedDimensionEvaluators
+    // with different template dimensions
+    union
+    {
+#define CODE(i) FixedDimensionEvaluator<FUNC,i, VECTOR> * eval##i;
+#include "codi/evaluator-macros.h"
+#undef CODE
+    } eval;
+    
+  public:
+    Evaluator(int nx, int ny, FUNC& func):
+      nx(nx)
+    {
+
+      // call constructor for origin dimension nx
+      switch(nx)
+      {
+#define CODE(i) case i: eval.eval##i=new FixedDimensionEvaluator<FUNC,i,VECTOR>(nx,ny,func); break;
+#include "codi/evaluator-macros.h"
+#undef CODE
+      default:
+        std::stringstream msg;
+        msg << "codi::Evaluator: unable to handle dimensions larger than " << CODI_MAXDIM;
+        throw std::domain_error(msg.str());
+      }
+      
+    }
+    
+    
+    /**
+     * @brief Call function for vector x
+     *
+     * The call is delegated to the proper FixedDimensionEvaluator
+     */
+    template <class V>
+    void call(const V& x)
+    {
+      // Delegate call
+      switch(nx)
+      {
+#define CODE(i) case i: eval.eval##i->call(x); break;
+#include "codi/evaluator-macros.h"
+#undef CODE
+      default: break;
+      }
+    }
+    
+    /**
+     * @brief Retrieve function value f_i(x)
+     *
+     * Note: we might check for matching dimensions
+     */
+    double result(int iy)
+    {
+      // Delegate call 
+      switch(nx)
+      {
+#define CODE(i) case i: return eval.eval##i->result(iy); 
+#include "codi/evaluator-macros.h"
+#undef CODE
+      default: return 0;
+      }
+    }
+    
+    /**
+     * @brief Retrieve jacobian value at d f_i(x)/d x_j
+     *
+     * Note: we might check for matching dimensions
+     */
+    double jacobian(int iy, int ix)
+    {
+      // Delegate call 
+      switch(nx)
+      {
+#define CODE(i) case i: return eval.eval##i->jacobian(iy,ix); 
+#include "codi/evaluator-macros.h"
+#undef CODE
+      default: return 0;
+      }
+    }
+    
+    ~Evaluator()
+    {
+      // Destroy the right FixedDimensionEvaluator
+      switch(nx)
+      {
+#define CODE(i) case i: delete eval.eval##i; break;
+#include "codi/evaluator-macros.h"
+#undef CODE
+      default: break;
+      }
+    }
+  };
+  
+
+#if __cplusplus >= 201703L
+  // C++ 17 template argument deduction allows to avoid template
+  // parameter in constructor of Evaluator
+  template<
+    class FUNC,
+    template <class T, class ALLOC> class VECTOR=std::vector
+    >
+  Evaluator(int x, int y, FUNC&func)  -> Evaluator<FUNC,VECTOR>;
+#endif
+  
+}


### PR DESCRIPTION
Hi,
after figuring out to use automatic differentiation with Julia I looked for options to do this in C++ (where we have most of  our existing codebase...). So I found codipack, and it seems very interesting. 

With this pull request I propose an API layer on top of codipack which allows to use templated functor classes (or generic lambdas for c++14) in order to have an easy to write way to specifiy functions to be differentiated.

For my use case, see j-fu/VoronoiFVM.jl. 

If it doesn't fit your philosophy, I would make this part of our code or provide this in another repo.

Best regards
Jürgen Fuhrmann (juergen.fuhrmann@wias-berlin.de)
