### PR TITLE
Add OpenMP dependency to the testing workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
       run: |
         sudo apt update
         sudo apt install -y clang
+        sudo apt install libomp-dev
     - name: General Tests
       run: |
         cd tests/general/


### PR DESCRIPTION
OpenMP is required for the tests of the multithreading features merged in 21e4f6e084d635e7834ca55dc9d83b667a5aca2b.