### PR TITLE
rsat fixes

### DIFF
--- a/include/codi/tapes/commonTapeImplementation.hpp
+++ b/include/codi/tapes/commonTapeImplementation.hpp
@@ -535,7 +535,7 @@ namespace codi {
           func.template call<callType>(&impl, dataView, std::forward<Args>(args)...);
 
           codiAssert(endPos == dataView.getPosition());
-        } else if (LowLevelFunctionEntryCallKind::Delete == callType) {
+        } else CODI_Unlikely if (LowLevelFunctionEntryCallKind::Delete == callType) {
           // No delete registered. Data is skiped by the curLLFByteDataPos update.
         } else {
           CODI_EXCEPTION("Requested call is not supported for low level function with token '%d'.", (int)id);

--- a/include/codi/tapes/commonTapeImplementation.hpp
+++ b/include/codi/tapes/commonTapeImplementation.hpp
@@ -535,9 +535,9 @@ namespace codi {
           func.template call<callType>(&impl, dataView, std::forward<Args>(args)...);
 
           codiAssert(endPos == dataView.getPosition());
-        } else if (LowLevelFunctionEntryCallKind::Delete == callType) CODI_Unlikely {
+        } else if (LowLevelFunctionEntryCallKind::Delete == callType) {
           // No delete registered. Data is skiped by the curLLFByteDataPos update.
-        } else CODI_Unlikely {
+        } else {
           CODI_EXCEPTION("Requested call is not supported for low level function with token '%d'.", (int)id);
         }
 

--- a/include/codi/tapes/jacobianBaseTape.hpp
+++ b/include/codi/tapes/jacobianBaseTape.hpp
@@ -867,7 +867,7 @@ namespace codi {
 
       CODI_NO_INLINE void internalResizeAdjointsVector() {
         // overallocate as next multiple of Config::ChunkSize
-        adjoints.resize((int)getNextMultiple((size_t)indexManager.get().getLargestCreatedIndex() + 1, Config::ChunkSize));
+        adjoints.resize(getNextMultiple(indexManager.get().getLargestCreatedIndex() + 1, (Identifier)Config::ChunkSize));
       }
   };
 }

--- a/include/codi/tapes/jacobianBaseTape.hpp
+++ b/include/codi/tapes/jacobianBaseTape.hpp
@@ -867,7 +867,7 @@ namespace codi {
 
       CODI_NO_INLINE void internalResizeAdjointsVector() {
         // overallocate as next multiple of Config::ChunkSize
-        adjoints.resize(getNextMultiple((size_t)indexManager.get().getLargestCreatedIndex() + 1, Config::ChunkSize));
+        adjoints.resize((int)getNextMultiple((size_t)indexManager.get().getLargestCreatedIndex() + 1, Config::ChunkSize));
       }
   };
 }

--- a/include/codi/tapes/jacobianLinearTape.hpp
+++ b/include/codi/tapes/jacobianLinearTape.hpp
@@ -200,7 +200,7 @@ namespace codi {
                                                                       // curAdjointPos at the end of the loop.
 
             EventSystem<JacobianLinearTape>::notifyStatementEvaluateListeners(
-                tape, (int)curAdjointPos, GradientTraits::dim<Adjoint>(), GradientTraits::toArray(lhsAdjoint).data());
+                tape, (Identifier)curAdjointPos, GradientTraits::dim<Adjoint>(), GradientTraits::toArray(lhsAdjoint).data());
 
             if (Config::ReversalZeroesAdjoints) {
               adjointVector[curAdjointPos] = Adjoint();

--- a/include/codi/tapes/jacobianLinearTape.hpp
+++ b/include/codi/tapes/jacobianLinearTape.hpp
@@ -200,7 +200,7 @@ namespace codi {
                                                                       // curAdjointPos at the end of the loop.
 
             EventSystem<JacobianLinearTape>::notifyStatementEvaluateListeners(
-                tape, curAdjointPos, GradientTraits::dim<Adjoint>(), GradientTraits::toArray(lhsAdjoint).data());
+                tape, (int)curAdjointPos, GradientTraits::dim<Adjoint>(), GradientTraits::toArray(lhsAdjoint).data());
 
             if (Config::ReversalZeroesAdjoints) {
               adjointVector[curAdjointPos] = Adjoint();


### PR DESCRIPTION
Hi Max, I recently compiled CoDiPack with an rsat checker and had to change these 3 places to make it work. 

for include/codi/tapes/commonTapeImplementation.hpp I get the error:
error: both branches of 'if' statement marked as 'unlikely' [-Werror=attributes]
394 |   #define CODI_Unlikely [[unlikely]]
note: in expansion of macro 'CODI_Unlikely'
538 |         } else if (LowLevelFunctionEntryCallKind::Delete == callType) CODI_Unlikely {

for include/codi/tapes/jacobianBaseTape.hpp I get the error:
error: conversion from 'long unsigned int' to 'codi::LocalAdjoints<double, int, codi::JacobianLinearTape<codi::JacobianTapeTypes<double, double, codi::LinearIndexManager<int>, codi::DefaultChunkedData, codi::LocalAdjoints> > >::Identifier' {aka 'int'} may change value [-Werror=conversion]
[build]   870 |         adjoints.resize(getNextMultiple((size_t)indexManager.get().getLargestCreatedIndex() + 1, Config::ChunkSize));

for include/codi/tapes/jacobianLinearTape.hpp I get the error:
error: conversion from 'size_t' {aka 'long unsigned int'} to 'codi::EventSystem<codi::JacobianLinearTape<codi::JacobianTapeTypes<double, double, codi::LinearIndexManager<int>, codi::DefaultChunkedData, codi::LocalAdjoints> > >::Identifier' {aka 'int'} may change value [-Werror=conversion]
203 |                 tape, curAdjointPos, GradientTraits::dim<Adjoint>(), GradientTraits::toArray(lhsAdjoint).data());

These changes make it work.