### PR TITLE
ignore .DS_Store for mac users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.autosave
 *.exe
 *.swp


### PR DESCRIPTION
Mac users get .DS_Store added in every read folder, and it ends up polluting the modified git files. 