### PR TITLE
add missing device annotation for transpose

### DIFF
--- a/include/codi/traits/computationTraits.hpp
+++ b/include/codi/traits/computationTraits.hpp
@@ -147,7 +147,7 @@ namespace codi {
       using Jacobian = T;
       using Return = T;
 
-      static Return transpose(Jacobian const& jacobian) {
+      CODI_INLINE static Return transpose(Jacobian const& jacobian) {
         return jacobian;
       }
   };


### PR DESCRIPTION
When compiling for CUDA using `clang++` (version 22.1.5), I got this error:

```
[...]/include/codi/expressions/../tapes/interfaces/../../traits/computationTraits.hpp:80:39: error: 
      reference to __host__ function 'transpose' in __host__ __device__ function
   80 |       return TransposeImpl<Jacobian>::transpose(jacobian);
```

`nvcc` compiled the same code with warnings about the missing annotation but consistently produced NaNs in the gradient output.

Adding `CODI_INLINE` on the `transpose` fixes both problems for me and I get correct gradients in a CUDA test case using the `codi::RealForwardCUDA` type.